### PR TITLE
FIX: Doc updated - Airflow local settings no longer importable from dags folder

### DIFF
--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -176,10 +176,8 @@ Some Airflow configuration is configured via local setting, because they require
 code that is executed when Airflow is initialized. Usually it is mentioned in the detailed documentation
 where you can configure such local settings - This is usually done in the ``airflow_local_settings.py`` file.
 
-You should create a ``airflow_local_settings.py`` file and put it in a directory in ``sys.path`` or
-in the ``$AIRFLOW_HOME/config`` folder. (Airflow adds ``$AIRFLOW_HOME/config`` to ``sys.path`` when
-Airflow is initialized).
-Note that starting from Airflow 2.10.1, the ``dags/`` folder is no longer included in ``sys.path`` during initialization, so local settings placed in ``$AIRFLOW_HOME/dags`` will not be imported automatically. Ensure that ``airflow_local_settings.py`` is in a location that is part of ``sys.path`` when Airflow is initialized, like ``$AIRFLOW_HOME/config``.
+You should create an airflow_local_settings.py file and place it in a directory that is part of sys.path, such as the $AIRFLOW_HOME/config folder (which Airflow automatically adds to sys.path during initialization). 
+Starting from Airflow 2.10.1, the $AIRFLOW_HOME/dags folder is no longer included in sys.path at initialization, so any local settings in that folder will not be imported. Ensure that airflow_local_settings.py is located in a path that is part of sys.path during initialization, like $AIRFLOW_HOME/config.
 
 
 You can see the example of such local settings here:

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -176,7 +176,10 @@ Some Airflow configuration is configured via local setting, because they require
 code that is executed when Airflow is initialized. Usually it is mentioned in the detailed documentation
 where you can configure such local settings - This is usually done in the ``airflow_local_settings.py`` file.
 
-You should create an ``airflow_local_settings.py`` file and place it in a directory that is in ``sys.path``, such as the ``$AIRFLOW_HOME/config`` folder. Note that starting from Airflow 2.10.1, the ``dags/`` folder is no longer included in ``sys.path`` during initialization, so local settings placed in ``$AIRFLOW_HOME/dags`` will not be imported automatically. Ensure that ``airflow_local_settings.py`` is in a location that is part of ``sys.path`` when Airflow is initialized, like ``$AIRFLOW_HOME/config``.
+You should create a ``airflow_local_settings.py`` file and put it in a directory in ``sys.path`` or
+in the ``$AIRFLOW_HOME/config`` folder. (Airflow adds ``$AIRFLOW_HOME/config`` to ``sys.path`` when
+Airflow is initialized).
+Note that starting from Airflow 2.10.1, the ``dags/`` folder is no longer included in ``sys.path`` during initialization, so local settings placed in ``$AIRFLOW_HOME/dags`` will not be imported automatically. Ensure that ``airflow_local_settings.py`` is in a location that is part of ``sys.path`` when Airflow is initialized, like ``$AIRFLOW_HOME/config``.
 
 
 You can see the example of such local settings here:

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -181,7 +181,6 @@ in the ``$AIRFLOW_HOME/config`` folder. (Airflow adds ``$AIRFLOW_HOME/config`` t
 Airflow is initialized)
 Starting from Airflow 2.10.1, the $AIRFLOW_HOME/dags folder is no longer included in sys.path at initialization, so any local settings in that folder will not be imported. Ensure that airflow_local_settings.py is located in a path that is part of sys.path during initialization, like $AIRFLOW_HOME/config.
 
-
 You can see the example of such local settings here:
 
 .. py:module:: airflow.config_templates.airflow_local_settings

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -176,9 +176,8 @@ Some Airflow configuration is configured via local setting, because they require
 code that is executed when Airflow is initialized. Usually it is mentioned in the detailed documentation
 where you can configure such local settings - This is usually done in the ``airflow_local_settings.py`` file.
 
-You should create a ``airflow_local_settings.py`` file and put it in a directory in ``sys.path`` or
-in the ``$AIRFLOW_HOME/config`` folder. (Airflow adds ``$AIRFLOW_HOME/config`` to ``sys.path`` when
-Airflow is initialized)
+You should create an ``airflow_local_settings.py`` file and place it in a directory that is in ``sys.path``, such as the ``$AIRFLOW_HOME/config`` folder. Note that starting from Airflow 2.10.1, the ``dags/`` folder is no longer included in ``sys.path`` during initialization, so local settings placed in ``$AIRFLOW_HOME/dags`` will not be imported automatically. Ensure that ``airflow_local_settings.py`` is in a location that is part of ``sys.path`` when Airflow is initialized, like ``$AIRFLOW_HOME/config``.
+
 
 You can see the example of such local settings here:
 

--- a/docs/apache-airflow/howto/set-config.rst
+++ b/docs/apache-airflow/howto/set-config.rst
@@ -176,7 +176,9 @@ Some Airflow configuration is configured via local setting, because they require
 code that is executed when Airflow is initialized. Usually it is mentioned in the detailed documentation
 where you can configure such local settings - This is usually done in the ``airflow_local_settings.py`` file.
 
-You should create an airflow_local_settings.py file and place it in a directory that is part of sys.path, such as the $AIRFLOW_HOME/config folder (which Airflow automatically adds to sys.path during initialization). 
+You should create a ``airflow_local_settings.py`` file and put it in a directory in ``sys.path`` or
+in the ``$AIRFLOW_HOME/config`` folder. (Airflow adds ``$AIRFLOW_HOME/config`` to ``sys.path`` when
+Airflow is initialized)
 Starting from Airflow 2.10.1, the $AIRFLOW_HOME/dags folder is no longer included in sys.path at initialization, so any local settings in that folder will not be imported. Ensure that airflow_local_settings.py is located in a path that is part of sys.path during initialization, like $AIRFLOW_HOME/config.
 
 


### PR DESCRIPTION
<!--
 Licensed to the Apache Software Foundation (ASF) under one
 or more contributor license agreements.  See the NOTICE file
 distributed with this work for additional information
 regarding copyright ownership.  The ASF licenses this file
 to you under the Apache License, Version 2.0 (the
 "License"); you may not use this file except in compliance
 with the License.  You may obtain a copy of the License at

   http://www.apache.org/licenses/LICENSE-2.0

 Unless required by applicable law or agreed to in writing,
 software distributed under the License is distributed on an
 "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
 KIND, either express or implied.  See the License for the
 specific language governing permissions and limitations
 under the License.
 -->

<!--
Thank you for contributing! Please make sure that your code changes
are covered with tests. And in case of new features or big changes
remember to adjust the documentation.

Feel free to ping committers for the review!

In case of an existing issue, reference it using one of the following:

closes: #42156
related: #42156

How to write a good git commit message:
http://chris.beams.io/posts/git-commit/
-->



<!-- Please keep an empty line above the dashes. -->
---
**^ Add meaningful description above**
Read the **[Pull Request Guidelines](https://github.com/apache/airflow/blob/main/contributing-docs/05_pull_requests.rst#pull-request-guidelines)** for more information.
In case of fundamental code changes, an Airflow Improvement Proposal ([AIP](https://cwiki.apache.org/confluence/display/AIRFLOW/Airflow+Improvement+Proposals)) is needed.
In case of a new dependency, check compliance with the [ASF 3rd Party License Policy](https://www.apache.org/legal/resolved.html#category-x).
In case of backwards incompatible changes please leave a note in a newsfragment file, named `{pr_number}.significant.rst` or `{issue_number}.significant.rst`, in [newsfragments](https://github.com/apache/airflow/tree/main/newsfragments).
